### PR TITLE
Remove `alpine` from being the required dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
-      - develop
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"

--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -76,6 +76,11 @@ jobs:
         id: github-meta
         uses: dockerbakery/github-metadata-action@v2
 
+      - name: Download and verify s6-overlay tarballs
+        run: |
+          docker buildx bake download --no-cache
+          docker buildx bake verify --no-cache
+
       - name: Build and push
         uses: docker/bake-action@v6
         with:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -59,6 +59,11 @@ jobs:
         id: github-meta
         uses: dockerbakery/github-metadata-action@v2
 
+      - name: Download and verify s6-overlay tarballs
+        run: |
+          docker buildx bake download --no-cache
+          docker buildx bake verify --no-cache
+
       - name: Build and push
         uses: docker/bake-action@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,12 @@ name: "Test"
 on:
   push:
     branches:
+      - develop
       - next
       - trunk
   pull_request:
     branches:
+      - develop
       - next
       - trunk
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-tarballs/
+output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,17 @@ WORKDIR /tmp/output
 RUN --mount=type=bind,source=./output,target=/tmp/output sha256sum -cw *.sha256
 
 # Specify the target architecture and variant for s6-overlay
+
+# | ${TARGETARCH} | ${arch} | Notes                 |
+# |:--------------|:--------|:----------------------|
+# | 386           | i686    | i486 for very old hw  |
+# | amd64         | x86_64  |                       |
+# | armv6         | armhf   | Raspberry Pi 1        |
+# | armv7         | arm     | armv7 with soft-float |
+# | arm64         | aarch64 |                       |
+# | riscv64       | riscv64 |                       |
+# | s390x         | s390x   |                       |
+
 # See https://github.com/just-containers/s6-overlay/blob/d6f37bb2052cfc5705154315419dcacb3975f11e/README.md?plain=1#L1023
 
 # s6-overlay-noarch.tar.xz

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,7 @@ ADD ${S6_DOWNLOAD_URL}/syslogd-overlay-noarch.tar.xz.sha256         /syslogd-ove
 
 FROM --platform=${BUILDPLATFORM} alpine:latest AS verify
 WORKDIR /tmp/output
-RUN --mount=type=bind,source=./output,target=/tmp/output <<EOT
-    set -e
-    sha256sum -cw *.sha256
-EOT
+RUN --mount=type=bind,source=./output,target=/tmp/output sha256sum -cw *.sha256
 
 # Specify the target architecture and variant for s6-overlay
 # See https://github.com/just-containers/s6-overlay/blob/d6f37bb2052cfc5705154315419dcacb3975f11e/README.md?plain=1#L1023

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,124 +1,94 @@
+ARG S6_REPO=just-containers/s6-overlay
 ARG S6_VERSION=v3.2.0.0
+ARG S6_DOWNLOAD_URL=https://github.com/${S6_REPO}/releases/download/${S6_VERSION}
 
-# Tools for building the s6-overlay images
-FROM alpine:latest AS internal
-RUN apk add --no-cache curl
-ARG TARGETARCH TARGETVARIANT
-RUN <<EOT
-    {
-    # See:
-    # https://github.com/just-containers/s6-overlay/blob/d6f37bb2052cfc5705154315419dcacb3975f11e/README.md?plain=1#L1023
-        case "${TARGETARCH}${TARGETVARIANT:+/}${TARGETVARIANT}" in
-            (amd64) echo 'x86_64' ;;
-            (arm64) echo 'aarch64' ;;
-            (riscv64) echo 'riscv64' ;;
-            (s390x) echo 's390x' ;;
-            (386) echo 'i686' ;;
-            (arm/v6) echo 'armhf' ;;
-            (arm/v7) echo 'arm' ;;
-            (*) echo 1>&2 'Unsupported architecture!' ; exit 1 ;;
-        esac
-    } >| /S6_ARCH
+# tarballs
+FROM scratch AS download
+ARG S6_DOWNLOAD_URL
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-aarch64.tar.xz                    /s6-overlay-aarch64.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-arm.tar.xz                        /s6-overlay-arm.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-armhf.tar.xz                      /s6-overlay-armhf.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-i486.tar.xz                       /s6-overlay-i486.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-i686.tar.xz                       /s6-overlay-i686.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-noarch.tar.xz                     /s6-overlay-noarch.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-powerpc64.tar.xz                  /s6-overlay-powerpc64.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-powerpc64le.tar.xz                /s6-overlay-powerpc64le.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-riscv64.tar.xz                    /s6-overlay-riscv64.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-s390x.tar.xz                      /s6-overlay-s390x.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-symlinks-arch.tar.xz              /s6-overlay-symlinks-arch.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-symlinks-noarch.tar.xz            /s6-overlay-symlinks-noarch.tar.xz
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-x86_64.tar.xz                     /s6-overlay-x86_64.tar.xz
+ADD ${S6_DOWNLOAD_URL}/syslogd-overlay-noarch.tar.xz                /syslogd-overlay-noarch.tar.xz
+
+# verify
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-aarch64.tar.xz.sha256             /s6-overlay-aarch64.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-arm.tar.xz.sha256                 /s6-overlay-arm.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-armhf.tar.xz.sha256               /s6-overlay-armhf.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-i486.tar.xz.sha256                /s6-overlay-i486.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-i686.tar.xz.sha256                /s6-overlay-i686.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-noarch.tar.xz.sha256              /s6-overlay-noarch.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-powerpc64.tar.xz.sha256           /s6-overlay-powerpc64.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-powerpc64le.tar.xz.sha256         /s6-overlay-powerpc64le.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-riscv64.tar.xz.sha256             /s6-overlay-riscv64.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-s390x.tar.xz.sha256               /s6-overlay-s390x.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-symlinks-arch.tar.xz.sha256       /s6-overlay-symlinks-arch.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-symlinks-noarch.tar.xz.sha256     /s6-overlay-symlinks-noarch.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/s6-overlay-x86_64.tar.xz.sha256              /s6-overlay-x86_64.tar.xz.sha256
+ADD ${S6_DOWNLOAD_URL}/syslogd-overlay-noarch.tar.xz.sha256         /syslogd-overlay-noarch.tar.xz.sha256
+
+FROM --platform=${BUILDPLATFORM} alpine:latest AS verify
+WORKDIR /tmp/output
+RUN --mount=type=bind,source=./output,target=/tmp/output <<EOT
+    set -e
+    sha256sum -cw *.sha256
 EOT
 
+# Specify the target architecture and variant for s6-overlay
+# See https://github.com/just-containers/s6-overlay/blob/d6f37bb2052cfc5705154315419dcacb3975f11e/README.md?plain=1#L1023
 
-# Overlay for s6-overlay-noarch.tar.xz & s6-overlay-${arch}.tar.xz
-FROM internal AS s6-overlay-rootfs
-ARG S6_VERSION
-RUN <<EOT
-    set -e
-    S6_ARCH=$(cat /S6_ARCH)
-    mkdir /s6-overlay-rootfs
-    set -x
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-noarch.tar.xz -o /tmp/s6-overlay-noarch.tar.xz
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-noarch.tar.xz.sha256 -o /tmp/s6-overlay-noarch.tar.xz.sha256
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.xz -o /tmp/s6-overlay-${S6_ARCH}.tar.xz
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.xz.sha256 -o /tmp/s6-overlay-${S6_ARCH}.tar.xz.sha256
-    cd   /tmp && sha256sum -c *.sha256
-    tar  -C /s6-overlay-rootfs -Jxpf /tmp/s6-overlay-noarch.tar.xz
-    tar  -C /s6-overlay-rootfs -Jxpf /tmp/s6-overlay-${S6_ARCH}.tar.xz
-EOT
-FROM scratch AS s6-overlay
-COPY --from=s6-overlay-rootfs /s6-overlay-rootfs /
+# s6-overlay-noarch.tar.xz
+FROM scratch AS s6-overlay-noarch
+ADD output/s6-overlay-noarch.tar.xz /
 
+# s6-overlay-i686.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-386
+ADD output/s6-overlay-i686.tar.xz /
 
-# Overlay for s6-overlay-symlinks-noarch.tar.xz & s6-overlay-symlinks-arch.tar.xz
-FROM --platform=${BUILDPLATFORM} internal AS s6-overlay-rootfs-symlinks
-ARG S6_VERSION
-RUN <<EOF
-    set -e
-    mkdir /s6-overlay-rootfs
-    set -x
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz -o /tmp/s6-overlay-symlinks-noarch.tar.xz
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz.sha256 -o /tmp/s6-overlay-symlinks-noarch.tar.xz.sha256
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz -o /tmp/s6-overlay-symlinks-arch.tar.xz
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz.sha256 -o /tmp/s6-overlay-symlinks-arch.tar.xz.sha256
-    cd   /tmp && sha256sum -c *.sha256
-    tar  -C /s6-overlay-rootfs -Jxpf /tmp/s6-overlay-symlinks-noarch.tar.xz
-    tar  -C /s6-overlay-rootfs -Jxpf /tmp/s6-overlay-symlinks-arch.tar.xz
-EOF
-FROM scratch AS s6-overlay-symlinks
-COPY --from=s6-overlay-rootfs-symlinks /s6-overlay-rootfs /
+# s6-overlay-x86_64.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-amd64
+ADD output/s6-overlay-x86_64.tar.xz /
 
+# s6-overlay-armhf.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-armv6
+ADD output/s6-overlay-armhf.tar.xz /
 
-# Overlay for syslogd-overlay-noarch.tar.xz
-FROM --platform=${BUILDPLATFORM} internal AS s6-overlay-rootfs-syslogd
-ARG S6_VERSION
-RUN <<EOF
-    set -e
-    mkdir /s6-overlay-rootfs
-    set -x
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/syslogd-overlay-noarch.tar.xz -o /tmp/syslogd-overlay-noarch.tar.xz
-    curl -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/syslogd-overlay-noarch.tar.xz.sha256 -o /tmp/syslogd-overlay-noarch.tar.xz.sha256
-    cd   /tmp && sha256sum -c *.sha256
-    tar  -C /s6-overlay-rootfs -Jxpf /tmp/syslogd-overlay-noarch.tar.xz
-EOF
-FROM scratch AS s6-overlay-syslogd
-COPY --from=s6-overlay-rootfs-syslogd /s6-overlay-rootfs /
+# s6-overlay-arm.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-armv7
+ADD output/s6-overlay-arm.tar.xz /
 
+# s6-overlay-aarch64.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-arm64
+ADD output/s6-overlay-aarch64.tar.xz /
 
-# Default image
-# This image is used as a base for other images that require s6-overlay.
+# s6-overlay-riscv64.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-riscv64
+ADD output/s6-overlay-riscv64.tar.xz /
+
+# s6-overlay-s390x.tar.xz
+FROM s6-overlay-noarch AS s6-overlay-s390x
+ADD output/s6-overlay-s390x.tar.xz /
+
+# s6-overlay
+FROM s6-overlay-${TARGETARCH}${TARGETVARIANT} AS s6-overlay
 FROM s6-overlay
 
 
-# s6-overlay tarballs
-FROM scratch AS tarballs
-ARG S6_VERSION
-# tarballs
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.xz /s6-overlay-aarch64.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-arm.tar.xz /s6-overlay-arm.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-armhf.tar.xz /s6-overlay-armhf.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-i486.tar.xz /s6-overlay-i486.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-i686.tar.xz /s6-overlay-i686.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-noarch.tar.xz /s6-overlay-noarch.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-powerpc64.tar.xz /s6-overlay-powerpc64.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-powerpc64le.tar.xz /s6-overlay-powerpc64le.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-riscv64.tar.xz /s6-overlay-riscv64.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-s390x.tar.xz /s6-overlay-s390x.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz /s6-overlay-symlinks-arch.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz /s6-overlay-symlinks-noarch.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-x86_64.tar.xz /s6-overlay-x86_64.tar.xz
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/syslogd-overlay-noarch.tar.xz /syslogd-overlay-noarch.tar.xz
-# checksums
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-aarch64.tar.xz.sha256 /s6-overlay-aarch64.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-arm.tar.xz.sha256 /s6-overlay-arm.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-armhf.tar.xz.sha256 /s6-overlay-armhf.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-i486.tar.xz.sha256 /s6-overlay-i486.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-i686.tar.xz.sha256 /s6-overlay-i686.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-noarch.tar.xz.sha256 /s6-overlay-noarch.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-powerpc64.tar.xz.sha256 /s6-overlay-powerpc64.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-powerpc64le.tar.xz.sha256 /s6-overlay-powerpc64le.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-riscv64.tar.xz.sha256 /s6-overlay-riscv64.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-s390x.tar.xz.sha256 /s6-overlay-s390x.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-arch.tar.xz.sha256 /s6-overlay-symlinks-arch.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-symlinks-noarch.tar.xz.sha256 /s6-overlay-symlinks-noarch.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-x86_64.tar.xz.sha256 /s6-overlay-x86_64.tar.xz.sha256
-ADD https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/syslogd-overlay-noarch.tar.xz.sha256 /syslogd-overlay-noarch.tar.xz.sha256
+# s6-overlay-symlinks-noarch.tar.xz & s6-overlay-symlinks-arch.tar.xz
+FROM scratch AS s6-overlay-symlinks
+ADD output/s6-overlay-symlinks-noarch.tar.xz /
+ADD output/s6-overlay-symlinks-arch.tar.xz /
 
-FROM alpine:latest AS checksums
-RUN --mount=type=bind,source=./tarballs,target=/tmp/tarballs <<EOT
-    set -e
-    cd /tmp/tarballs
-    sha256sum -c *.sha256
-EOT
+
+# syslogd-overlay-noarch.tar.xz
+FROM scratch AS s6-overlay-syslogd
+ADD output/syslogd-overlay-noarch.tar.xz /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG S6_REPO=just-containers/s6-overlay
 ARG S6_VERSION=v3.2.0.0
 ARG S6_DOWNLOAD_URL=https://github.com/${S6_REPO}/releases/download/${S6_VERSION}
 
-# tarballs
+# Download s6-overlay tarballs for various architectures
+# $ docker buildx bake download --no-cache
 FROM scratch AS download
 ARG S6_DOWNLOAD_URL
 ADD ${S6_DOWNLOAD_URL}/s6-overlay-aarch64.tar.xz                    /s6-overlay-aarch64.tar.xz
@@ -20,7 +21,8 @@ ADD ${S6_DOWNLOAD_URL}/s6-overlay-symlinks-noarch.tar.xz            /s6-overlay-
 ADD ${S6_DOWNLOAD_URL}/s6-overlay-x86_64.tar.xz                     /s6-overlay-x86_64.tar.xz
 ADD ${S6_DOWNLOAD_URL}/syslogd-overlay-noarch.tar.xz                /syslogd-overlay-noarch.tar.xz
 
-# verify
+# Verify the downloaded tarballs
+# $ docker buildx bake verify --no-cache
 ADD ${S6_DOWNLOAD_URL}/s6-overlay-aarch64.tar.xz.sha256             /s6-overlay-aarch64.tar.xz.sha256
 ADD ${S6_DOWNLOAD_URL}/s6-overlay-arm.tar.xz.sha256                 /s6-overlay-arm.tar.xz.sha256
 ADD ${S6_DOWNLOAD_URL}/s6-overlay-armhf.tar.xz.sha256               /s6-overlay-armhf.tar.xz.sha256
@@ -76,6 +78,7 @@ FROM s6-overlay-noarch AS s6-overlay-s390x
 ADD output/s6-overlay-s390x.tar.xz /
 
 # s6-overlay
+# This is the default target for s6-overlay, the architecture and variant will be determined by the build platform
 FROM s6-overlay-${TARGETARCH}${TARGETVARIANT} AS s6-overlay
 FROM s6-overlay
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-it: dockerhub
+it: download
 
 .PHONY: dockerhub
 dockerhub:
 	@bash dockerhub/README.sh
+
+download:
+	docker buildx bake download --no-cache
+	docker buildx bake verify --no-cache
+
 build:
-	@docker buildx bake dev --load
+	@docker buildx bake build --print

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,6 +4,16 @@ variable "S6_VERSION" { default = "v3.2.0.0" }
 target "docker-metadata-action" {}
 target "github-metadata-action" {}
 
+# Download s6-overlay tarballs for local testing.
+target "download" {
+    output = ["./output"]
+    platforms = ["local"]
+    target = "download"
+}
+target "verify" {
+    target = "verify"
+}
+
 group "default" {
     targets = [
         "s6-overlay",
@@ -50,31 +60,31 @@ target "s6-overlay-syslogd" {
     target = "s6-overlay-syslogd"
 }
 
-# The "release" group is used to build locally in the event that CI/CD is not available.
+# The "build" group is used to build locally in the event that CI/CD is not available.
 # Or in most cases, it got rate-limited by Docker Hub.
-# e.g: S6_VERSION=v3.2.0.0 docker buildx bake release --push
-group "release" {
+# e.g: S6_VERSION=v3.2.0.0 docker buildx bake build --push
+group "build" {
     targets = [
-        "release-s6-overlay",
-        "release-s6-overlay-symlinks",
-        "release-s6-overlay-syslogd",
+        "build-s6-overlay",
+        "build-s6-overlay-symlinks",
+        "build-s6-overlay-syslogd",
     ]
 }
-target "release-s6-overlay" {
+target "build-s6-overlay" {
     inherits = [ "s6-overlay" ]
     tags = [ 
         "docker.io/socheatsok78/s6-overlay:${S6_VERSION}",
         "ghcr.io/socheatsok78/s6-overlay:${S6_VERSION}",
     ]
 }
-target "release-s6-overlay-symlinks" {
+target "build-s6-overlay-symlinks" {
     inherits = [ "s6-overlay-symlinks" ]
     tags = [ 
         "docker.io/socheatsok78/s6-overlay:${S6_VERSION}-symlinks",
         "ghcr.io/socheatsok78/s6-overlay:${S6_VERSION}-symlinks",
     ]
 }
-target "release-s6-overlay-syslogd" {
+target "build-s6-overlay-syslogd" {
     inherits = [ "s6-overlay-syslogd" ]
     tags = [ 
         "docker.io/socheatsok78/s6-overlay:${S6_VERSION}-syslogd",
@@ -107,14 +117,4 @@ target "local-s6-overlay-syslogd" {
     inherits = [ "local-s6-overlay" ]
     target = "s6-overlay-syslogd"
     tags = [ "socheatsok78/s6-overlay:${S6_VERSION}-syslogd"]
-}
-
-# Download s6-overlay tarballs for local testing.
-target "tarballs" {
-    output = ["./tarballs"]
-    platforms = ["local"]
-    target = "tarballs"
-}
-target "checksums" {
-    target = "checksums"
 }


### PR DESCRIPTION
Instead of using `alpine` image to download and verify `s6-overlay` tarballs, instead use the `ADD instruction` to grab the tarballs and only use `alpine` for verify the checksum.

The we only need one intermediate layer for the `s6-overlay-noarch.tar.xz` and use `TARGETARCH` and `TARGETVARIANT` to perform platform selection. 

This will results in quicker build and less depends on `alpine` and less likely to get rate-limited by Docker again!