### PR TITLE
Implement strict validation check for S6_VERSION variable

### DIFF
--- a/.github/workflows/use-docker-build-test.yml
+++ b/.github/workflows/use-docker-build-test.yml
@@ -29,6 +29,7 @@ on:
         required: false
         type: string
         default: ''
+
 env:
   S6_VERSION: ${{ inputs.tag_name }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The S6_VERSION variable is used to specify the version of s6-overlay to build.
 # It MUST NOT provides any default value.
-# It is expected to be set by the user when running the build command.
+# It is expected to be set by the user or CI when running the build command.
 #
 # e.g: S6_VERSION=v3.2.0.0 docker buildx bake build
 ARG S6_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# The S6_VERSION variable is used to specify the version of s6-overlay to build.
+# It MUST NOT provides any default value.
+# It is expected to be set by the user when running the build command.
+#
+# e.g: S6_VERSION=v3.2.0.0 docker buildx bake build
 ARG S6_VERSION
 
 ARG S6_REPO=just-containers/s6-overlay

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
+ARG S6_VERSION
+
 ARG S6_REPO=just-containers/s6-overlay
-ARG S6_VERSION=v3.2.0.0
 ARG S6_DOWNLOAD_URL=https://github.com/${S6_REPO}/releases/download/${S6_VERSION}
 ARG ALPINE_VERSION=3.22.0
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -33,12 +33,14 @@ target "tarballs" {
     output = ["./output"]
     platforms = ["local"]
     target = "tarballs"
+    no-cache = true
 }
 target "verify" {
     args = {
         S6_VERSION = "${S6_VERSION}"
     }
     target = "verify"
+    no-cache = true
 }
 
 group "default" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,6 @@
 
-variable "S6_VERSION" { default = "v3.2.0.0" }
+variable "S6_VERSION" {
+}
 variable "ALPINE_VERSION" { default = "3.22.0" }
 
 target "docker-metadata-action" {}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,19 @@
-
+# The S6_VERSION variable is used to specify the version of s6-overlay to build.
+# It MUST NOT provides any default value.
+# It is expected to be set by the user when running the build command.
+#
+# e.g: S6_VERSION=v3.2.0.0 docker buildx bake build
 variable "S6_VERSION" {
+    validation {
+        condition = S6_VERSION != ""
+        error_message = "S6_VERSION must not be empty."
+    }
+    validation {
+        condition = S6_VERSION == regex("^v[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+$", S6_VERSION)
+        error_message = "S6_VERSION must be set to a valid version."
+    }
 }
+
 variable "ALPINE_VERSION" { default = "3.22.0" }
 
 target "docker-metadata-action" {}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,6 +1,6 @@
 # The S6_VERSION variable is used to specify the version of s6-overlay to build.
 # It MUST NOT provides any default value.
-# It is expected to be set by the user when running the build command.
+# It is expected to be set by the user or CI when running the build command.
 #
 # e.g: S6_VERSION=v3.2.0.0 docker buildx bake build
 variable "S6_VERSION" {


### PR DESCRIPTION
Since `S6_VERSION` was original defined defaults, failure to set `S6_VERSION` causing the container to grab `s6-overlay` the wrong version from what It suppose to get. 

By removing default value and implement strict validation check, this should no longer be an issue. This should fix #5.

See #5 for more info.
